### PR TITLE
#17 feat: 단일 게시글 상세 정보 및 댓글 목록 조회 api 구현

### DIFF
--- a/src/main/java/org/mas/mistory/controller/PostController.java
+++ b/src/main/java/org/mas/mistory/controller/PostController.java
@@ -2,6 +2,7 @@ package org.mas.mistory.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.mas.mistory.dto.CreatePostRequest;
+import org.mas.mistory.dto.PostDetailResponse;
 import org.mas.mistory.dto.PostListResponse;
 import org.mas.mistory.entity.BoardType;
 import org.mas.mistory.entity.Post;
@@ -21,7 +22,8 @@ public class PostController {
     private final PostService postService;
 
     // board_type(카테고리)별로 게시글 조회
-    @GetMapping("/posts/{boardType}")
+    // @GetMapping("/posts/{boardType}")
+    @RequestMapping(value = "/posts/{boardType}", method = RequestMethod.GET, params = "type=boardType")
     public ResponseEntity<List<PostListResponse>> getPostsByBoardType(@PathVariable BoardType boardType) {
         List<PostListResponse> posts = postService.getPostsByBoardType(boardType);
         return ResponseEntity.ok().body(posts);
@@ -34,5 +36,13 @@ public class PostController {
 
         return ResponseEntity.status(HttpStatus.CREATED).body("게시글이 작성되었습니다.");
 
+    }
+
+    // 게시글 및 댓글 목록 상세 조회
+    @GetMapping("/posts/{postId}")
+    public ResponseEntity<PostDetailResponse> getPostDetail(@PathVariable Long postId) {
+        PostDetailResponse postDetail = postService.getPostDetail(postId);
+
+        return ResponseEntity.ok().body(postDetail);
     }
 }

--- a/src/main/java/org/mas/mistory/dto/CommentResponse.java
+++ b/src/main/java/org/mas/mistory/dto/CommentResponse.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class CommentResponse {
+    private Long commentId;
     private String content;
-    private String userName;
+    private String nickname;
     private boolean isPrivate;
 }

--- a/src/main/java/org/mas/mistory/dto/PostDetailResponse.java
+++ b/src/main/java/org/mas/mistory/dto/PostDetailResponse.java
@@ -1,0 +1,17 @@
+package org.mas.mistory.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@AllArgsConstructor
+@Getter
+public class PostDetailResponse {
+    private Long postId;
+    private String title;
+    private String content;
+    private LocalDate postDate;
+    private List<CommentResponse> comments;
+}

--- a/src/main/java/org/mas/mistory/service/CommentService.java
+++ b/src/main/java/org/mas/mistory/service/CommentService.java
@@ -1,5 +1,6 @@
 package org.mas.mistory.service;
 
+import lombok.RequiredArgsConstructor;
 import org.mas.mistory.dto.CommentResponse;
 import org.mas.mistory.entity.Comment;
 import org.mas.mistory.repository.CommentRepository;
@@ -10,10 +11,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class CommentService {
 
-    @Autowired
-    private CommentRepository commentRepository;
+    private final CommentRepository commentRepository;
 
     // 비밀댓글 여부가 true이면 댓글 내용을 "비밀 댓글입니다.", 사용자 이름을 "***"으로 return
 //    public List<CommentResponse> getCommentsByPostId(Long postId) {

--- a/src/main/java/org/mas/mistory/service/PostService.java
+++ b/src/main/java/org/mas/mistory/service/PostService.java
@@ -1,11 +1,15 @@
 package org.mas.mistory.service;
 
 import lombok.RequiredArgsConstructor;
+import org.mas.mistory.dto.CommentResponse;
 import org.mas.mistory.dto.CreatePostRequest;
+import org.mas.mistory.dto.PostDetailResponse;
 import org.mas.mistory.dto.PostListResponse;
 import org.mas.mistory.entity.BoardType;
+import org.mas.mistory.entity.Comment;
 import org.mas.mistory.entity.Member;
 import org.mas.mistory.entity.Post;
+import org.mas.mistory.repository.CommentRepository;
 import org.mas.mistory.repository.MemberRepository;
 import org.mas.mistory.repository.PostRepository;
 import org.springframework.stereotype.Service;
@@ -20,6 +24,7 @@ public class PostService {
 
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
 
     public List<PostListResponse> getPostsByBoardType(BoardType boardType) {
         List<Post> posts = postRepository.findAllByBoardType(boardType);
@@ -47,5 +52,27 @@ public class PostService {
                 .build();
 
         return postRepository.save(post);
+    }
+
+    public PostDetailResponse getPostDetail(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new RuntimeException("해당 게시글을 찾을 수 없습니다."));
+
+        List<Comment> comments = commentRepository.findByPostId(postId);
+        List<CommentResponse> commentResponses = comments.stream()
+                .map(comment -> new CommentResponse(
+                        comment.getId(),
+                        comment.isPrivate() ? "비밀 댓글입니다." : comment.getContent(),
+                        comment.isPrivate() ? "***" : comment.getMember().getNickname(),
+                        comment.isPrivate()))
+                .collect(Collectors.toList());
+
+        return new PostDetailResponse(
+                post.getId(),
+                post.getTitle(),
+                post.getContent(),
+                post.getPostDate(),
+                commentResponses
+        );
     }
 }


### PR DESCRIPTION
- PostDetailResponse dto를 만들고, List<CommentResponse> 필드를 추가하였습니다.