### PR TITLE
#20 feat: 작성한 댓글 조회 api 구현 / fix: 카테고리별 게시글 조회 api를 @GetMapping으로 변경

### DIFF
--- a/src/main/java/org/mas/mistory/controller/CommentController.java
+++ b/src/main/java/org/mas/mistory/controller/CommentController.java
@@ -1,28 +1,34 @@
 package org.mas.mistory.controller;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.mas.mistory.dto.CommentResponse;
+import org.mas.mistory.dto.UserCommentResponse;
 import org.mas.mistory.entity.Comment;
 import org.mas.mistory.service.CommentService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
+@RequiredArgsConstructor
 @Slf4j
 public class CommentController {
 
-    @Autowired
-    private CommentService commentService;
+    private final CommentService commentService;
 
-    // 특정 게시글에 달린 댓글 조회
-//    @GetMapping("/posts/{postId}/comments")
-//    public ResponseEntity<List<CommentResponse>> getCommentsByPostId(@PathVariable Long postId) {
-//        List<CommentResponse> comments = commentService.getCommentsByPostId(postId);
-//        return ResponseEntity.ok().body(comments);
-//    }
+    @GetMapping("/comments")
+    public ResponseEntity<List<UserCommentResponse>> getComments() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String username = authentication.getName();
+
+        List<UserCommentResponse> comments = commentService.getComments(username);
+
+        return ResponseEntity.ok().body(comments);
+    }
+
 }

--- a/src/main/java/org/mas/mistory/controller/PostController.java
+++ b/src/main/java/org/mas/mistory/controller/PostController.java
@@ -1,6 +1,7 @@
 package org.mas.mistory.controller;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.mas.mistory.dto.CreatePostRequest;
 import org.mas.mistory.dto.PostDetailResponse;
 import org.mas.mistory.dto.PostListResponse;
@@ -17,14 +18,15 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 public class PostController {
 
     private final PostService postService;
 
     // board_type(카테고리)별로 게시글 조회
-    // @GetMapping("/posts/{boardType}")
-    @RequestMapping(value = "/posts/{boardType}", method = RequestMethod.GET, params = "type=boardType")
+    @GetMapping("/posts/boards/{boardType}")
     public ResponseEntity<List<PostListResponse>> getPostsByBoardType(@PathVariable BoardType boardType) {
+        log.info("BoardType: " + boardType);
         List<PostListResponse> posts = postService.getPostsByBoardType(boardType);
         return ResponseEntity.ok().body(posts);
     }

--- a/src/main/java/org/mas/mistory/dto/UserCommentResponse.java
+++ b/src/main/java/org/mas/mistory/dto/UserCommentResponse.java
@@ -1,0 +1,11 @@
+package org.mas.mistory.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserCommentResponse {
+    private Long commentId;
+    private String content;
+}

--- a/src/main/java/org/mas/mistory/entity/BoardType.java
+++ b/src/main/java/org/mas/mistory/entity/BoardType.java
@@ -4,5 +4,6 @@ public enum BoardType {
     GUESTBOOK,  // 방명록
     SCHOOL,     // 학교생활
     DORMITORY,  // 기숙사
-    ENTRANCE    // 입학
+    ENTRANCE,   // 입학
+    EMPLOYMENT  // 취업
 }

--- a/src/main/java/org/mas/mistory/entity/Comment.java
+++ b/src/main/java/org/mas/mistory/entity/Comment.java
@@ -12,6 +12,7 @@ public class Comment {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
     private Long id; // 댓글 기본키
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/org/mas/mistory/repository/CommentRepository.java
+++ b/src/main/java/org/mas/mistory/repository/CommentRepository.java
@@ -1,10 +1,15 @@
 package org.mas.mistory.repository;
 
+import org.mas.mistory.dto.UserCommentResponse;
 import org.mas.mistory.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByPostId(Long postId);
+
+    List<Comment> findByMemberId(Long userId);
 }

--- a/src/main/java/org/mas/mistory/service/CommentService.java
+++ b/src/main/java/org/mas/mistory/service/CommentService.java
@@ -2,9 +2,13 @@ package org.mas.mistory.service;
 
 import lombok.RequiredArgsConstructor;
 import org.mas.mistory.dto.CommentResponse;
+import org.mas.mistory.dto.UserCommentResponse;
 import org.mas.mistory.entity.Comment;
+import org.mas.mistory.entity.Member;
 import org.mas.mistory.repository.CommentRepository;
+import org.mas.mistory.repository.MemberRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -15,16 +19,19 @@ import java.util.stream.Collectors;
 public class CommentService {
 
     private final CommentRepository commentRepository;
+    private final MemberRepository memberRepository;
 
-    // 비밀댓글 여부가 true이면 댓글 내용을 "비밀 댓글입니다.", 사용자 이름을 "***"으로 return
-//    public List<CommentResponse> getCommentsByPostId(Long postId) {
-//        List<Comment> comments = commentRepository.findByPostId(postId);
-//        return comments.stream()
-//                .map(comment -> new CommentResponse(
-//                        comment.isPrivate() ? "비밀 댓글입니다." : comment.getContent(),
-//                        comment.isPrivate() ? "***" : comment.getUser().getUserName(), // User의 이름 가져오기
-//                        comment.isPrivate()
-//                ))
-//                .collect(Collectors.toList());
-//    }
+    public List<UserCommentResponse> getComments(String username) {
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 유저를 찾을 수 없습니다."));
+
+        List<Comment> comments = commentRepository.findByMemberId(member.getId());
+
+        return comments.stream()
+                .map(comment -> new UserCommentResponse(
+                        comment.getId(),
+                        comment.getContent()
+                ))
+                .collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
- 현재 로그인한 유저가 작성한 댓글 목록을 조회하는 api를 구현하였습니다.
- 카테고리별 게시글 조회 api에서 enum 타입의 경로 변수를 변환하지 못하는 버그가 생겨, @RequestMapping에서 @GetMapping 방식으로 수정하여 해결했습니다.