### PR TITLE
#23 refactor: qna 게시글과 댓글 동시에 가져오도록 수정

### DIFF
--- a/src/main/java/org/mas/mistory/entity/BoardType.java
+++ b/src/main/java/org/mas/mistory/entity/BoardType.java
@@ -1,7 +1,6 @@
 package org.mas.mistory.entity;
 
 public enum BoardType {
-    GUESTBOOK,  // 방명록
     SCHOOL,     // 학교생활
     DORMITORY,  // 기숙사
     ENTRANCE,   // 입학

--- a/src/main/java/org/mas/mistory/repository/CommentRepository.java
+++ b/src/main/java/org/mas/mistory/repository/CommentRepository.java
@@ -5,6 +5,8 @@ import org.mas.mistory.entity.BoardType;
 import org.mas.mistory.entity.Comment;
 import org.mas.mistory.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,6 +14,9 @@ import java.util.List;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByPostId(Long postId);
-
     List<Comment> findByMemberId(Long userId);
+
+    // Comment 엔티티를 기준으로 Post와 Member 엔티티를 조인하여 특정 게시판 타입의 게시글 및 댓글 정보를 가져오는 쿼리
+    @Query("SELECT c FROM Comment c JOIN FETCH c.post p JOIN FETCH c.member WHERE p.boardType = :boardType")
+    List<Comment> findCommentsWithPostsByBoardType(@Param("boardType") BoardType boardType);
 }

--- a/src/main/java/org/mas/mistory/repository/GuestbookRepository.java
+++ b/src/main/java/org/mas/mistory/repository/GuestbookRepository.java
@@ -1,7 +1,12 @@
 package org.mas.mistory.repository;
 
 import org.mas.mistory.entity.Guestbook;
+import org.mas.mistory.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface GuestbookRepository extends JpaRepository<Guestbook, Long> {
 }

--- a/src/main/java/org/mas/mistory/repository/PostRepository.java
+++ b/src/main/java/org/mas/mistory/repository/PostRepository.java
@@ -1,13 +1,15 @@
 package org.mas.mistory.repository;
 
 import org.mas.mistory.entity.BoardType;
+import org.mas.mistory.entity.Comment;
 import org.mas.mistory.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
-    List<Post> findAllByBoardType(BoardType boardType);
 }


### PR DESCRIPTION
- 게시글 상세 페이지 기능 제외에 따라 조회 기능을 수정하였습니다.
  - 기존: 게시글의 제목, 본문 내용만 가져오고, 클릭하면 해당 게시글의 상세 내용 및 댓글 목록 조회
  - 수정 후: 게시글의 제목, 본문 내용과 해당 게시글의 댓글 목록을 동시에 조회