### PR TITLE
#37 fix: LinkedHashMap을 사용해서 순서대로 게시글 및 댓글 조회되게 수정

### DIFF
--- a/src/main/java/org/mas/mistory/service/PostService.java
+++ b/src/main/java/org/mas/mistory/service/PostService.java
@@ -18,6 +18,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.LinkedHashMap;
 
 @Service
 @RequiredArgsConstructor
@@ -82,8 +83,15 @@ public class PostService {
         List<Comment> comments = commentRepository.findCommentsWithPostsByBoardType(boardType);
 
         // Post 엔티티를 기준으로 그룹화
+        /* Map<Post, List<Comment>> postCommentsMap = comments.stream()
+                .collect(Collectors.groupingBy(Comment::getPost)); */
+
         Map<Post, List<Comment>> postCommentsMap = comments.stream()
-                .collect(Collectors.groupingBy(Comment::getPost));
+                .collect(Collectors.groupingBy(
+                        Comment::getPost,
+                        LinkedHashMap::new,
+                        Collectors.toList()
+                ));
 
         // 각 Post 엔티티에 대해 PostWithCommentResponse 생성
         return postCommentsMap.entrySet().stream()


### PR DESCRIPTION
- 기존의 Map에서 LinkedHashMap으로 변경하여 순서대로 조회되게 수정하였습니다.