### PR TITLE
fix: 로그인 실패시 화면 리로드되게 수정

### DIFF
--- a/src/main/java/org/mas/mistory/config/LoginFailHandler.java
+++ b/src/main/java/org/mas/mistory/config/LoginFailHandler.java
@@ -16,7 +16,6 @@ public class LoginFailHandler extends SimpleUrlAuthenticationFailureHandler {
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
                                         AuthenticationException exception) throws IOException, ServletException {
 
-        // log.info("Authentication failed: " + exception.getMessage());
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Authentication failed");
+        response.sendRedirect("http://127.0.0.1:5501/Mistory/login.html?fail=true");
     }
 }

--- a/src/main/java/org/mas/mistory/config/SecurityConfig.java
+++ b/src/main/java/org/mas/mistory/config/SecurityConfig.java
@@ -32,7 +32,6 @@ public class SecurityConfig {
                 )
                 .formLogin((form) -> form
                         .loginProcessingUrl("/login")
-                        // .defaultSuccessUrl("/login_success", true)
                         .successHandler(new LoginSuccessHandler())
                         .failureHandler(new LoginFailHandler())
                 )


### PR DESCRIPTION
- 파라미터 값을 이용하여 로그인 실패시 401 에러페이지로 넘어가지 않고, 다시 로그인 페이지로 넘어갈 수 있도록 하였습니다.